### PR TITLE
Add Python script to convert midi to scad params

### DIFF
--- a/midi2musicbox/README.md
+++ b/midi2musicbox/README.md
@@ -1,0 +1,19 @@
+# midi2musicbox
+
+The url referenced in the scad file to generate notes (http://www.wizards23.net/projects/musicbox/musicbox.html) longer exists and isn't available on archive sites after searching. This is a python script to emulate some of the functionality that likely existed there. Simply pass in a (relatively simple) .midi file that features only a melody or simple chords, and it will print out the respective variable values to overwrite in the scad file to have it generate the .midi tune in a physical model to print.
+## Usage
+`./midi2musicbox.sh <your_song.midi>`
+This will create a python virtual environment in this directory (if it doesn't already exist), install the necessary dependencies, and then parse the midi to generate the relevant paramters to be substituted in the scad file.
+
+Example:
+```sh
+$ ./midi2musicbox.sh september.mid  
+
+MusicCylinderName="september";
+pinNrX = 8;
+pinNrY = 46;
+teethNotes = "F#0A 0B 0C 1C#1D 1E 1F#1";
+pins = "XooooooooXooooooooXoooooooooXoooooooXoooooooooooooooooooooooooooooooXoooooooooXooooooooXooXooooooXooooooooooooooooXooooooooooXooooooXooooooooooooooooooooooooooooXooooooooXoooooooooXoooooooooXooooooooXooXooooooXooooooooooooooooooXooooooooXooooooXooooooooooooooooooooooooooooXooooooooXoooooooooXoooooooooXooooooooXoooXooooooXooooooooooooooXooooooooXooooooXooooooXXXXXXXX";
+```
+
+overwrite the variables featured in the .scad file with the files in this output and re-render the model to get the .stl of the physical implementation of the song.

--- a/midi2musicbox/midi2musicbox.sh
+++ b/midi2musicbox/midi2musicbox.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o nounset
+set -o errexit
+
+midi="${1:-$(1>&2 echo 'Error: no midi file provided'; exit 1)}"
+
+if ! [ -d venv ]; then
+	python3 -m venv venv
+	. venv/bin/activate
+	pip3 install -r requirements.txt
+fi
+
+. venv/bin/activate
+
+python3 midi2notes.py $midi

--- a/midi2musicbox/midi2notes.py
+++ b/midi2musicbox/midi2notes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+import mido
+import sys
+import midi_numbers
+
+
+def midi_notes2scad_notes(midi_notes):
+  return [
+    '{0: <2}'.format(
+      ( key_note := midi_numbers.number_to_note( midi_note ) )[0]
+    ) + str(key_note[1])
+  for midi_note in midi_notes
+]
+
+
+def midi_msgs2midi_notes(midi_track):
+  return [ msg.note for msg in midi_track if msg.type == "note_on" ]
+
+
+def get_distinct_midi_notes(midi_track):
+  return list({ msg.note for msg in midi_track if msg.type == "note_on" })
+
+
+def normalize_scad_notes(scad_notes, min_octave):
+  """Lowest note should be in octave 0, adjust other octaves relatively"""
+  return [ note[:2] + str(int(note[2]) - min_octave) for note in scad_notes ]
+
+
+midi=mido.MidiFile(sys.argv[1])
+midi_track = midi.tracks[1]
+
+distinct_midi_notes            = get_distinct_midi_notes(midi_track)
+distinct_scad_notes            = midi_notes2scad_notes(distinct_midi_notes)
+min_octave                     = int(min([n[2] for n in distinct_scad_notes]))
+normalized_distinct_scad_notes = normalize_scad_notes(distinct_scad_notes, min_octave)
+distinct_note_quantity         = len(distinct_midi_notes)
+
+midi_track_dict = [ m.dict() for m in midi_track ]
+
+note_events = [
+  { k:m[k] for k in ['note', 'time', 'type'] }
+  for m in midi_track_dict if m['type'] in [ "note_on" , "note_off"]
+]
+
+absolute_time = 0
+for e in note_events:
+  absolute_time += e['time']
+  e['T'] = absolute_time
+
+note_events = [
+  { k:e[k] for k in ['note', 'T'] }
+  for e in note_events if e['type'] ==  "note_on"
+]
+
+min_ticks_between_notes=0xffffffff
+for i in range(1,len(note_events)):
+  t_delta = note_events[i]['T'] - note_events[i-1]['T']
+  if t_delta < min_ticks_between_notes:
+    min_ticks_between_notes = t_delta
+
+for e in note_events:
+  e['T'] = round(e['T'] / min_ticks_between_notes)
+
+total_measures = note_events[-1]['T'] + 1
+cylinder_rows = [ [0] * distinct_note_quantity for i in range(total_measures) ]
+
+for e in note_events:
+  note_index = distinct_midi_notes.index(e['note'])
+  cylinder_rows[e['T']][note_index] = 1
+
+
+# Visually mark end of song with row of all notes
+cylinder_rows.append( [1] * distinct_note_quantity)
+total_measures += 1
+
+
+# OpenSCAD file params
+pinNrX = distinct_note_quantity
+pinNrY = total_measures
+teethNotes = "".join(normalized_distinct_scad_notes)
+pins = "".join([ "".join(map(lambda n: 'X' if n else 'o', r)) for r in cylinder_rows ])
+
+print(f"""
+MusicCylinderName="{midi.filename.split('.mid')[0]}";
+pinNrX = {pinNrX};
+pinNrY = {pinNrY};
+teethNotes = "{teethNotes}";
+pins = "{pins}";
+""")

--- a/midi2musicbox/midi_numbers.py
+++ b/midi2musicbox/midi_numbers.py
@@ -1,0 +1,171 @@
+INSTRUMENTS = [
+    'Acoustic Grand Piano',
+    'Bright Acoustic Piano',
+    'Electric Grand Piano',
+    'Honky-tonk Piano',
+    'Electric Piano 1',
+    'Electric Piano 2',
+    'Harpsichord',
+    'Clavi',
+    'Celesta',
+    'Glockenspiel',
+    'Music Box',
+    'Vibraphone',
+    'Marimba',
+    'Xylophone',
+    'Tubular Bells',
+    'Dulcimer',
+    'Drawbar Organ',
+    'Percussive Organ',
+    'Rock Organ',
+    'Church Organ',
+    'Reed Organ',
+    'Accordion',
+    'Harmonica',
+    'Tango Accordion',
+    'Acoustic Guitar (nylon)',
+    'Acoustic Guitar (steel)',
+    'Electric Guitar (jazz)',
+    'Electric Guitar (clean)',
+    'Electric Guitar (muted)',
+    'Overdriven Guitar',
+    'Distortion Guitar',
+    'Guitar harmonics',
+    'Acoustic Bass',
+    'Electric Bass (finger)',
+    'Electric Bass (pick)',
+    'Fretless Bass',
+    'Slap Bass 1',
+    'Slap Bass 2',
+    'Synth Bass 1',
+    'Synth Bass 2',
+    'Violin',
+    'Viola',
+    'Cello',
+    'Contrabass',
+    'Tremolo Strings',
+    'Pizzicato Strings',
+    'Orchestral Harp',
+    'Timpani',
+    'String Ensemble 1',
+    'String Ensemble 2',
+    'SynthStrings 1',
+    'SynthStrings 2',
+    'Choir Aahs',
+    'Voice Oohs',
+    'Synth Voice',
+    'Orchestra Hit',
+    'Trumpet',
+    'Trombone',
+    'Tuba',
+    'Muted Trumpet',
+    'French Horn',
+    'Brass Section',
+    'SynthBrass 1',
+    'SynthBrass 2',
+    'Soprano Sax',
+    'Alto Sax',
+    'Tenor Sax',
+    'Baritone Sax',
+    'Oboe',
+    'English Horn',
+    'Bassoon',
+    'Clarinet',
+    'Piccolo',
+    'Flute',
+    'Recorder',
+    'Pan Flute',
+    'Blown Bottle',
+    'Shakuhachi',
+    'Whistle',
+    'Ocarina',
+    'Lead 1 (square)',
+    'Lead 2 (sawtooth)',
+    'Lead 3 (calliope)',
+    'Lead 4 (chiff)',
+    'Lead 5 (charang)',
+    'Lead 6 (voice)',
+    'Lead 7 (fifths)',
+    'Lead 8 (bass + lead)',
+    'Pad 1 (new age)',
+    'Pad 2 (warm)',
+    'Pad 3 (polysynth)',
+    'Pad 4 (choir)',
+    'Pad 5 (bowed)',
+    'Pad 6 (metallic)',
+    'Pad 7 (halo)',
+    'Pad 8 (sweep)',
+    'FX 1 (rain)',
+    'FX 2 (soundtrack)',
+    'FX 3 (crystal)',
+    'FX 4 (atmosphere)',
+    'FX 5 (brightness)',
+    'FX 6 (goblins)',
+    'FX 7 (echoes)',
+    'FX 8 (sci-fi)',
+    'Sitar',
+    'Banjo',
+    'Shamisen',
+    'Koto',
+    'Kalimba',
+    'Bag pipe',
+    'Fiddle',
+    'Shanai',
+    'Tinkle Bell',
+    'Agogo',
+    'Steel Drums',
+    'Woodblock',
+    'Taiko Drum',
+    'Melodic Tom',
+    'Synth Drum',
+    'Reverse Cymbal',
+    'Guitar Fret Noise',
+    'Breath Noise',
+    'Seashore',
+    'Bird Tweet',
+    'Telephone Ring',
+    'Helicopter',
+    'Applause',
+    'Gunshot'
+]
+NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+OCTAVES = list(range(11))
+NOTES_IN_OCTAVE = len(NOTES)
+
+errors = {
+    'program': 'Bad input, please refer this spec-\n'
+               'http://www.electronics.dit.ie/staff/tscarff/Music_technology/midi/program_change.htm',
+    'notes': 'Bad input, please refer this spec-\n'
+             'http://www.electronics.dit.ie/staff/tscarff/Music_technology/midi/midi_note_numbers_for_octaves.htm'
+}
+
+
+def instrument_to_program(instrument: str) -> int:
+    assert instrument in INSTRUMENTS, errors['program']
+    return INSTRUMENTS.index(instrument) + 1
+
+
+def program_to_instrument(program: int) ->  str:
+    assert 1 <= program <= 128, errors['program']
+    return INSTRUMENTS[program - 1]
+
+
+def number_to_note(number: int) -> tuple:
+    octave = number // NOTES_IN_OCTAVE
+    assert octave in OCTAVES, errors['notes']
+    assert 0 <= number <= 127, errors['notes']
+    note = NOTES[number % NOTES_IN_OCTAVE]
+
+    return note, octave
+
+
+def note_to_number(note: str, octave: int) -> int:
+    assert note in NOTES, errors['notes']
+    assert octave in OCTAVES, errors['notes']
+
+    note = NOTES.index(note)
+    note += (NOTES_IN_OCTAVE * octave)
+
+    assert 0 <= note <= 127, errors['notes']
+
+    return note

--- a/midi2musicbox/requirements.txt
+++ b/midi2musicbox/requirements.txt
@@ -1,0 +1,2 @@
+mido
+py_midicsv


### PR DESCRIPTION
As mentioned in the included README:
>The url referenced in the scad file to generate notes (http://www.wizards23.net/projects/musicbox/musicbox.html) longer exists and isn't available on archive sites after searching. This is a python script to emulate some of the functionality that likely existed there.

This script takes a .midi file and generates the source-code to be substituted in your .scad file file to generate the model that plays the melody in the.midi file.

Example usage:
```sh
$ ./midi2musicbox.sh september.midi
MusicCylinderName="september";
pinNrX = 8;
pinNrY = 46;
teethNotes = "F#0A 0B 0C 1C#1D 1E 1F#1";
pins = "XooooooooXooooooooXoooooooooXoooooooXoooooooooooooooooooooooooooooooXoooooooooXooooooooXooXooooooXooooooooooooooooXooooooooooXooooooXooooooooooooooooooooooooooooXooooooooXoooooooooXoooooooooXooooooooXooXooooooXooooooooooooooooooXooooooooXooooooXooooooooooooooooooooooooooooXooooooooXoooooooooXoooooooooXooooooooXoooXooooooXooooooooooooooXooooooooXooooooXooooooXXXXXXXX";
```